### PR TITLE
feat: Added a styleguide generator from the components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,15 @@
   ],
   "plugins": [
     "transform-decorators-legacy"
-  ]
+  ],
+  "env": {
+    "production": {
+      "plugins": [
+        ["transform-react-remove-statics", {
+          "displayName": true,
+          "styleguide": true
+        }]
+      ],
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+dist

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint:fix": "npm run lint -- --fix",
     "test": "NODE_PATH=./src:./test mocha src/**/__tests__/*.js src/**/**/__tests__/*.js",
     "test:watch": "npm run test -- --watch",
-    "test:cov": "babel-node `npm bin`/istanbul cover `npm bin`/_mocha -- --recursive"
+    "test:cov": "babel-node `npm bin`/istanbul cover `npm bin`/_mocha -- --recursive",
+    "styleguide": "rsg -c styleguide.js 'src/components/!(__tests__)/*.js'",
+    "styleguide:watch": "rsg -c styleguide.js 'src/components/!(__tests__)/*.js' -d"
   },
   "repository": {
     "type": "git",
@@ -54,6 +56,7 @@
     "babel-loader": "^6.2.1",
     "babel-plugin-react-transform": "2.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
+    "babel-plugin-transform-react-remove-statics": "0.0.5",
     "babel-preset-es2015": "6.5.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-0": "6.5.0",
@@ -86,6 +89,7 @@
     "redux-devtools": "^3.0.1",
     "redux-devtools-dock-monitor": "^1.0.1",
     "redux-devtools-log-monitor": "^1.0.2",
+    "rsg-alt": "*",
     "strip-loader": "^0.1.0",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.6",

--- a/src/components/Books/Form.js
+++ b/src/components/Books/Form.js
@@ -1,9 +1,32 @@
 import React, { Component, PropTypes } from 'react';
 import styles from './Books.css';
 
+/**
+ * Display a book search form
+ */
 export default class Form extends Component {
+  static displayName = 'Form';
+
   static propTypes = {
+    /**
+     * Handler for form submission
+     */
     onSubmit: PropTypes.func.isRequired
+  };
+
+  static styleguide = {
+    category: 'Books',
+    index: '2.0',
+    title: 'Form',
+    exampleComponent: Form,
+    examples: [
+      {
+        tabTitle: 'Sample',
+        props: {
+          onSubmit: () => { console.log('Form onSubmit'); }
+        }
+      }
+    ]
   };
 
   handleSearch(event) {

--- a/src/components/Books/List.js
+++ b/src/components/Books/List.js
@@ -1,17 +1,59 @@
 import React, { Component, PropTypes } from 'react';
-import { List } from 'immutable';
+import { List, fromJS } from 'immutable';
 import styles from './Books.css';
 
-export default class BooksList extends Component {
+/**
+ * List of search results
+ */
+export default class BookList extends Component {
+  static displayName = 'List';
+
   static propTypes = {
+    /**
+     * Array of books (`List`)
+     */
     items: PropTypes.instanceOf(List)
   };
+
+  static styleguide = {
+    category: 'Books',
+    index: '2.2',
+    title: 'List',
+    exampleComponent: BookList,
+    examples: [
+      {
+        tabTitle: 'Multiple Items',
+        props: {
+          items: fromJS([
+            {
+              id: 1,
+              volumeInfo: {
+                title: 'Book A'
+              }
+            },
+            {
+              id: 2,
+              volumeInfo: {
+                title: 'Book B'
+              }
+            }
+          ])
+        }
+      },
+      {
+        tabTitle: 'Empty',
+        props: {
+          items: List([])
+        }
+      }
+    ]
+  }
 
   render() {
     const { items } = this.props;
     return (
       <div>
-        {items.map((book) => {
+        {(items || []).map((book) => {
           return (
             <p className={styles.listItem} key={book.get('id')}>{book.get('volumeInfo').get('title')}</p>
           );

--- a/src/components/Books/SearchStatus.js
+++ b/src/components/Books/SearchStatus.js
@@ -1,11 +1,52 @@
 import React, { Component, PropTypes } from 'react';
 import styles from './Books.css';
 
+/**
+ * Text display for the book search status
+ */
 export default class SearchStatus extends Component {
+  static displayName = 'SearchStatus';
+
   static propTypes = {
+    /**
+     * If the search is in progress
+     */
     isFetching: PropTypes.bool,
+    /**
+     * if the search failed
+     */
     didInvalidate: PropTypes.bool
   };
+
+  static styleguide = {
+    category: 'Books',
+    index: '2.1',
+    title: 'SearchStatus',
+    exampleComponent: SearchStatus,
+    examples: [
+      {
+        tabTitle: 'Searching',
+        props: {
+          isFetching: true,
+          didInvalidate: false
+        }
+      },
+      {
+        tabTitle: 'Uh Oh',
+        props: {
+          isFetching: false,
+          didInvalidate: true
+        }
+      },
+      {
+        tabTitle: 'Hidden',
+        props: {
+          isFetching: false,
+          didInvalidate: false
+        }
+      }
+    ]
+  }
 
   message() {
     if (this.props.isFetching) {

--- a/src/components/Counter/Button.js
+++ b/src/components/Counter/Button.js
@@ -1,11 +1,50 @@
 import React, { Component, PropTypes } from 'react';
 import styles from './Counter.css';
 
+/**
+ * A simple button to style for the counter and capture clicks.
+ */
 export default class Button extends Component {
-  static propTypes ={
+  static displayName = 'Button';
+
+  static propTypes = {
+    /**
+     * Handler for click event
+     */
     onClick: PropTypes.func.isRequired,
+    /**
+     * Text to display inside the button
+     */
     text: PropTypes.string.isRequired,
-    type: PropTypes.string.isRequired
+    /**
+     * Name of button style `'positive|negative'`
+     */
+    type: PropTypes.oneOf(['positive', 'negative']).isRequired
+  };
+
+  static styleguide = {
+    index: '1.2',
+    category: 'Counter',
+    title: 'Button',
+    exampleComponent: Button,
+    examples: [
+      {
+        tabTitle: 'Positive',
+        props: {
+          type: 'positive',
+          text: '+',
+          onClick: () => { console.log('Positive button onClick'); }
+        }
+      },
+      {
+        tabTitle: 'Negative',
+        props: {
+          type: 'negative',
+          text: '-',
+          onClick: () => { console.log('Negative button onClick'); }
+        }
+      }
+    ]
   };
 
   render() {

--- a/src/components/Counter/Counter.js
+++ b/src/components/Counter/Counter.js
@@ -2,11 +2,42 @@ import React, { Component, PropTypes } from 'react';
 import Display from './Display';
 import Button from './Button';
 
+/**
+ * A +1/-1 counter and display
+ */
 export default class Counter extends Component {
-  static propTypes ={
+  static displayName = 'Counter';
+
+  static propTypes = {
+    /**
+     * Handler for incrementing
+     */
     onIncrement: PropTypes.func.isRequired,
+    /**
+     * Handler for decrementing
+     */
     onDecrement: PropTypes.func.isRequired,
+    /**
+     * Display the current count
+     */
     count: PropTypes.number.isRequired
+  };
+
+  static styleguide = {
+    category: 'Counter',
+    index: '1.0',
+    title: 'Counter',
+    exampleComponent: Counter,
+    examples: [
+      {
+        tabTitle: 'Sample',
+        props: {
+          count: 1,
+          onIncrement: () => { console.log('Counter onIncrement'); },
+          onDecrement: () => { console.log('Counter onDecrement'); }
+        }
+      }
+    ]
   };
 
   render() {

--- a/src/components/Counter/Display.js
+++ b/src/components/Counter/Display.js
@@ -1,9 +1,24 @@
 import React, { Component, PropTypes } from 'react';
 import styles from './Counter.css';
 
+/**
+ * Display a count
+ */
 export default class Display extends Component {
-  static propTypes ={
+  static displayName = 'Display';
+
+  static propTypes = {
+    /**
+     * Number to display
+     */
     count: PropTypes.number.isRequired
+  };
+
+  static styleguide = {
+    category: 'Counter',
+    index: '1.1',
+    title: 'Display',
+    code: `<Display count={1} />`
   };
 
   render() {

--- a/styleguide.js
+++ b/styleguide.js
@@ -1,0 +1,20 @@
+const path = require('path');
+
+module.exports = {
+  title: 'React Redux Starter Kit Style Guide',
+  files: [
+    '//cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css'
+  ],
+  output: 'dist/styleguide',
+  webpackConfig: {
+    module: {
+      loaders: [
+        {
+          test: /\.css$/,
+          include: path.join(__dirname, 'src'),
+          loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[path][name]-[local]!autoprefixer-loader?browsers=last 3 version'
+        }
+      ]
+    }
+  }
+};


### PR DESCRIPTION
Setup react-styleguide-alt to generate a styleguide. These will also be published to github pages.

```
# creates it in `dist/styleguide`
npm run styleguide

# runs a server at localhost:3000
npm run styleguide:watch 
```

I've opened an issue to [hide the example tab](https://github.com/theogravity/react-styleguide-generator-alt/issues/21) and to [pass along required props](https://github.com/theogravity/react-styleguide-generator-alt/issues/22). They're annoying on this branch, but not blocking.
