### PR TITLE
chore(README): Add semantic release and travis build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # React + Redux Starter Kit
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=plastic)](https://github.com/semantic-release/semantic-release)
+![Build Status](https://travis-ci.org/rentpath/react-redux-starter-kit.svg?branch=master)
 
 This starter kit is intended to gather best practices and experiment with new libs.
 


### PR DESCRIPTION
Just adds some badges to the `README`
